### PR TITLE
Disable services exporter via flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+openstack-exporter
 
 # Test binary, build with `go test -c`
 *.test

--- a/main.go
+++ b/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
-	"gopkg.in/alecthomas/kingpin.v2"
-	"net/http"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 func EnableExporter(service string, prefix string, config *Cloud) (*OpenStackExporter, error) {
@@ -18,7 +20,7 @@ func EnableExporter(service string, prefix string, config *Cloud) (*OpenStackExp
 	return &exporter, nil
 }
 
-var enabledServices = []string{"network", "compute", "image", "volume", "identity"}
+var defaultEnabledServices = []string{"network", "compute", "image", "volume", "identity"}
 
 func main() {
 	var (
@@ -29,11 +31,17 @@ func main() {
 		cloud          = kingpin.Arg("cloud", "name or id of the cloud to gather metrics from").Required().String()
 	)
 
-	log.Infoln("Starting openstack exporter", version.Info())
-	log.Infoln("Build context", version.BuildContext())
-
+	services := make(map[string]*bool)
+	for _, service := range defaultEnabledServices {
+		flagName := fmt.Sprintf("disable-service.%s", service)
+		flagHelp := fmt.Sprintf("Disable the %s service exporter", service)
+		services[service] = kingpin.Flag(flagName, flagHelp).Default().Bool()
+	}
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
+
+	log.Infoln("Starting openstack exporter", version.Info())
+	log.Infoln("Build context", version.BuildContext())
 
 	config, err := NewCloudConfigFromFile(*osClientConfig)
 	if err != nil {
@@ -45,12 +53,14 @@ func main() {
 		panic(err)
 	}
 
-	for _, service := range enabledServices {
-		_, err := EnableExporter(service, *prefix, cloudConfig)
-		if err != nil {
-			panic(err)
+	for service, disabled := range services {
+		if !*disabled {
+			_, err := EnableExporter(service, *prefix, cloudConfig)
+			if err != nil {
+				panic(err)
+			}
+			log.Infoln("Enabled exporter for", service)
 		}
-		log.Infoln("Enabled exporter for", service)
 	}
 
 	http.Handle(*metrics, promhttp.Handler())


### PR DESCRIPTION
DIsable OpenStack services exporter by `--disable-service.xxx` flag.

Command `./openstack-exporter --help` Output:

```bash
usage: openstack-exporter [<flags>] <cloud>

Flags:
  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
      --web.listen-address=":9180"  
                                 address:port to listen on
      --web.telemetry-path="/metrics"  
                                 uri path to expose metrics
      --os-client-config="/etc/openstack/clouds.yml"  
                                 Path to the cloud configuration file
      --prefix="openstack"       Prefix for metrics
      --disable-service.network  Disable the network service exporter
      --disable-service.compute  Disable the compute service exporter
      --disable-service.image    Disable the image service exporter
      --disable-service.volume   Disable the volume service exporter
      --disable-service.identity  
                                 Disable the identity service exporter

Args:
  <cloud>  name or id of the cloud to gather metrics from
```